### PR TITLE
Use k8s service discovery for ocr service

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,14 @@ $ docker push <docker_username>/rotisserie-app
   $ export token="YOUR_OAUTH_TOKEN"
 ```
 
-* Create an environment variable for the OCR_HOST. This can be set to localhost:3001
-  or the IP address + port of a remote OCR host.
+
+
+* Create an environment variable for the ROTISSERIE_OCR_SERVICE_HOST and ROTISSERIE_OCR_SERVICE_PORT. This can be set to ``localhost`` and ``3001``
+  or the IP address and port of a remote OCR host. Mimic the environment variables exported by kubernetes.
 
 ```shell
-  $ export OCR_HOST="localhost:3001"
+  $ export ROTISSERIE_OCR_SERVICE_HOST="localhost"
+  $ export ROTISSERIE_OCR_SERVICE_PORT="3001"
 ```
 
 * Navigate to the `rotisserie` dir if you aren't there already, and start
@@ -135,7 +138,7 @@ You can also run rotisserie in a docker container.
 
 ```shell
   $ docker run -d -p 3001:3001 --name rotisserie-ocr <docker_username>/rotisserie-ocr
-  $ docker run -d --name rotisserie-app --link rotisserie-ocr:rotisserie-ocr -p 3000:3000 -e OCR_HOST=rotisserie-ocr:3001 -e token=$token <docker_username>/rotisserie-app
+  $ docker run -d --name rotisserie-app --link rotisserie-ocr:rotisserie-ocr -p 3000:3000 -e ROTISSERIE_OCR_SERVICE_HOST=rotisserie-ocr -e ROTISSERIE_OCR_SERVICE_PORT=3001 -e token=$token <docker_username>/rotisserie-app
 ```
 
 Now you can open a browser and navigate to `http://localhost:3000` to watch

--- a/app.js
+++ b/app.js
@@ -200,8 +200,12 @@ function ocrCroppedShot(options) {
                                  + options.streamName + ".png"),
     };
 
+    // k8s injects the following variables
+    // ROTISSERIE_OCR_SERVICE_HOST=10.10.10.65
+    // ROTISSERIE_OCR_SERVICE_PORT=3001
+
     let requestOptions = {
-      url: "http://" + process.env.OCR_HOST + "/process_pubg",
+      url: "http://" + process.env.ROTISSERIE_OCR_SERVICE_HOST + ":" + process.env.ROTISSERIE_OCR_SERVICE_PORT + "/process_pubg",
       formData: formData,
     };
 

--- a/deploy/rotisserie.yaml
+++ b/deploy/rotisserie.yaml
@@ -121,7 +121,3 @@ spec:
         backend:
           serviceName: rotisserie-app
           servicePort: 3000
-      - path: /process_pubg
-        backend:
-          serviceName: rotisserie-ocr
-          servicePort: 3001


### PR DESCRIPTION
Prior to this, the main app was told by environment variable where the
OCR service was located. The location was the main website and the
/process_pubg endpoint. This meant we had to pipe /process_pubg through
to the ocr service in the ingress controller, which also introduced some
SSL issues.

Now, the main app looks at injected kubernetes environment variables to
discover where the ocr service is running, and hits it directly over
http.

This has probably broken the 'run containers locally' instructions,
which hopefully someone can noodle about. We don't want to inject
environment vars at build time that are later needed by k8s... even if
they might get overwritten.