### PR TITLE
Force ssl redirection in ingress controller

### DIFF
--- a/deploy/rotisserie.yaml
+++ b/deploy/rotisserie.yaml
@@ -106,6 +106,7 @@ metadata:
   name: rotisserie-ingress
   annotations:
     kubernetes.io/tls-acme: "true"
+    ingress.kubernetes.io/ssl-redirect: "true"
 spec:
   tls:
   - secretName: rotisserie-tls


### PR DESCRIPTION
This will ensure requests to rotisserie.tv get redirected to https.
Currently, if you do not specify https and don't have something like
https-everywhere enabled, the default nginx splash page will appear
rather than the rotisserie UI.

Signed-off-by: Cullen Taylor <cullentaylor@outlook.com>