### PR TITLE
Added clientID to secrets to support new api

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ rotisserie.
 $ echo -n "YOUR_OAUTH_TOKEN" | base64
 ```
 
-2. Modify the token-secret.yaml file to use your token
+2. Modify the twitch-auth-secrets.yaml file to use your token
 
 ```yaml
 ...
@@ -176,7 +176,7 @@ data:
 3. Finally, create the Kubernetes Secret.
 
 ```shell
-$ kubectl create -f token-secret.yaml
+$ kubectl create -f twitch-auth-secrets.yaml
 ```
 
 4. Modify the `rotisserie-app.yaml` and `rotisserie-ocr.yaml` yaml files to use your image.

--- a/deploy/rotisserie.yaml
+++ b/deploy/rotisserie.yaml
@@ -72,12 +72,12 @@ spec:
           - name: token
             valueFrom:
               secretKeyRef:
-                name: rotisserie
-                key: api-key
+                name: twitch-auth
+                key: token
           - name: clientID
             valueFrom:
               secretKeyRef:
-                name: rotisserie
+                name: twitch-auth
                 key: clientID
           - name: OCR_HOST
             value: rotisserie.tv

--- a/rotisserie-app.yaml
+++ b/rotisserie-app.yaml
@@ -36,6 +36,11 @@ spec:
         - name: token
           valueFrom:
             secretKeyRef:
-              name: twitch-token
+              name: twitch-auth
               key: token
+        - name: clientID
+          valueFrom:
+            secretKeyRef:
+              name: twitch-auth
+              key: clientID
           #USE SECRET

--- a/twitch-auth-secrets.yaml
+++ b/twitch-auth-secrets.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: twitch-token
+  name: twitch-auth
 type: Opaque
 data:
   token: YOUR_OAUTH_TOKEN_IN_BASE64
+  clientID: YOUR_CLIENT_ID_IN_BASE64


### PR DESCRIPTION
Changed token-secrets to twitch-auth-secrets so that we can add clientID to the same secret. Changed references for rotisserie secrets to twitch-auth so that the production application matches one off kubernetes deployments. 