### PR TITLE
Add checks for inside 10 players and 1 player

### DIFF
--- a/ocr.js
+++ b/ocr.js
@@ -60,11 +60,9 @@ app.post("/process_pubg", upload.single("image"), function(req, res, next) {
     } else {
       let number = parseFloat(text.trim());
       // Return any garbage as 100 (dead, out of game, etc)
-      if (isNaN(number)) {
-        number = 100;
-      }
       // Return <0 as 100. 0 isn't possible and it is usually a 100
-      if (number <= 0) {
+      // Return 1 as 100. 1 is endgame.
+      if (isNaN(number) || number <= 0 || number == 1) {
         number = 100;
       }
       let result = {

--- a/public/js/rotisserie.js
+++ b/public/js/rotisserie.js
@@ -23,7 +23,7 @@ $(document).ready(function() {
       $("#next_closest").text(secondResult["stream_name"]
         + " - " + secondResult["alive"]);
 
-      if (currentStream != topResult["stream_url"] ) {
+      if (currentStream != topResult["stream_url"] && !(topResult >= 10)) {
         $("#twitch_iframe").prop("src", topResult["stream_url"]);
       }
     });


### PR DESCRIPTION
* Add check for games inside 10 players. If inside 10, the iframe will not
  update client-side.
* Add check for games at 1 player alive to process_pubg.

Signed-off-by: Cullen Taylor <cullentaylor@outlook.com>