### PR TITLE
Adjust crop area for test server and 1.0

### DIFF
--- a/app.js
+++ b/app.js
@@ -171,7 +171,7 @@ function cropScreenshot(options) {
     console.log("cropping screenshot of stream: " + options.streamName);
     if (fs.existsSync(options.thumbnailsDir + options.streamName + ".png")) {
       gm(options.thumbnailsDir + options.streamName + ".png")
-        .crop(28, 20, 1190, 25)
+        .crop(22, 22, 1190, 20)
         .type("Grayscale")
         .write(options.cropsDir + options.streamName + ".png", function(err) {
           resolve(options);


### PR DESCRIPTION
The box containing the number of players alive has shifted slightly
with the test server (and 1.0 pubg release on the 12/20/2017). This
will correct the cropScreenshots function to center over this new
location.

We might not want to merge yet, but most people streaming PUBG will
be streaming the test server until the 1.0 release, and this will
need to be fixed anyway.

Signed-off-by: Cullen Taylor <cullentaylor@outlook.com>