### PR TITLE
Removed default-http-backend and added static

### DIFF
--- a/deploy/kube-lego.yaml
+++ b/deploy/kube-lego.yaml
@@ -61,7 +61,7 @@ spec:
         - containerPort: 443
         args:
         - /nginx-ingress-controller
-        - --default-backend-service=default/default-http-backend
+        - --default-backend-service=default/rotisserie-static
         - --nginx-configmap=default/nginx
 ---
 apiVersion: v1
@@ -78,37 +78,6 @@ spec:
     name: https
   selector:
     app: nginx
----
-apiVersion: extensions/v1beta1
-kind: Deployment
-metadata:
-  name: default-http-backend
-  namespace: default
-spec:
-  replicas: 1
-  template:
-    metadata:
-      labels:
-        app: default-http-backend
-    spec:
-      containers:
-      - name: default-http-backend
-        image: gcr.io/google_containers/defaultbackend:1.0
-        ports:
-        - containerPort: 8080
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: default-http-backend
-  namespace: default
-spec:
-  ports:
-  - port: 80
-    targetPort: 8080
-    protocol: TCP
-  selector:
-    app: default-http-backend
 ---
 apiVersion: v1
 data:

--- a/docs/architecture/kubernetes.md
+++ b/docs/architecture/kubernetes.md
@@ -254,7 +254,7 @@ spec:
         - containerPort: 443
         args:
         - /nginx-ingress-controller
-        - --default-backend-service=default/default-http-backend
+        - --default-backend-service=default/rotisserie-static
         - --nginx-configmap=default/nginx
 ```
 


### PR DESCRIPTION
Replaced default-http-backend with rotisserie-static in the kube-lego.yaml. We can use the static container as the default backend to provide 404s. Removed default-http-backend deployment and service setup in kube-lego.yaml. Updated documentation to reflect new values in yaml examples. 