### PR TITLE
Update package.json to reflect new npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rotisserie
 
-[![npm version](https://badge.fury.io/js/pubgredzone.svg)](https://badge.fury.io/js/pubgredzone)
+[![npm version](https://badge.fury.io/js/rotisserietv.svg)](https://badge.fury.io/js/rotisserietv)
 [![Build Status](https://api.travis-ci.org/IBM/rotisserie.svg?branch=master)](https://travis-ci.org/IBM/rotisserie)
 [![Docker Automated build](https://img.shields.io/docker/automated/jrottenberg/ffmpeg.svg)](https://hub.docker.com/r/eggshell/rotisserie/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rotisserie",
+  "name": "rotisserietv",
   "version": "0.0.1",
   "description": "webapp for viewing the most exciting PlayerUnknown's BattleGrounds streams on Twitch",
   "main": "index.js",


### PR DESCRIPTION
I went ahead and published rotisserie to npm. However, the name
rotisserie was taken on npmjs, is deprecated, but seems to still be
kept around for unknown reasons. This will update the name of the
package in package.json as well as the npm badge in the readme, as it
previously pointed to the old pubgredzone package which is super old.

Signed-off-by: Cullen Taylor <cullentaylor@outlook.com>