### PR TITLE
Added RBAC for Kube-Lego

### DIFF
--- a/deploy/kube-lego.yaml
+++ b/deploy/kube-lego.yaml
@@ -91,3 +91,16 @@ kind: ConfigMap
 metadata:
   namespace: default
   name: nginx
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: nginx-ingress-rbac
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Added RBAC ClusterRoleBinding so that Kube-Lego resources have enough permissions to read ingress resources. 