### PR TITLE
Revert back to bluemix container registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ SHELL := /bin/bash
 REV_FILE=.make-rev-check
 
 ## Workflow
-## export docker_username=''
 ## export APP_HOSTNAME=''
 ##
 ## edit -
@@ -35,19 +34,17 @@ images: set-rev
 	./deploy/images/make-image.sh deploy/images/ocr.Dockerfile "rotisserie-ocr:$$(cat $(REV_FILE))"
 	./deploy/images/make-image.sh deploy/images/static-server.Dockerfile "rotisserie-static:$$(cat $(REV_FILE))"
 
-# Tags images for the app, ocr, and static containers based on the docker_username environment variable. Runs
-# set-rev to ensure that the rev_file exists.
+# Tags images for the app, ocr, and static containers. Runs set-rev to ensure that the rev_file exists.
 tag-images: set-rev
-	docker tag "rotisserie-app:$$(cat $(REV_FILE))" "$$docker_username/rotisserie-app:$$(cat $(REV_FILE))"
-	docker tag "rotisserie-ocr:$$(cat $(REV_FILE))" "$$docker_username/rotisserie-ocr:$$(cat $(REV_FILE))"
-	docker tag "rotisserie-static:$$(cat $(REV_FILE))" "$$docker_username/rotisserie-static:$$(cat $(REV_FILE))"
+	docker tag "rotisserie-app:$$(cat $(REV_FILE))" "registry.ng.bluemix.net/rotisserie/rotisserie-app:$$(cat $(REV_FILE))"
+	docker tag "rotisserie-ocr:$$(cat $(REV_FILE))" "registry.ng.bluemix.net/rotisserie/rotisserie-ocr:$$(cat $(REV_FILE))"
+	docker tag "rotisserie-static:$$(cat $(REV_FILE))" "registry.ng.bluemix.net/rotisserie/rotisserie-static:$$(cat $(REV_FILE))"
 
-# Uploads images to dockerhub. Uses the docker_username environment variable. Runs set-rev to ensure that the
-# rev_file exists.
+# Uploads images to IBM Cointainer Repository. Runs set-rev to ensure that the rev_file exists.
 upload-images: set-rev
-	docker push "$$docker_username/rotisserie-app:$$(cat $(REV_FILE))"
-	docker push "$$docker_username/rotisserie-ocr:$$(cat $(REV_FILE))"
-	docker push "$$docker_username/rotisserie-static:$$(cat $(REV_FILE))"
+	docker push "registry.ng.bluemix.net/rotisserie/rotisserie-app:$$(cat $(REV_FILE))"
+	docker push "registry.ng.bluemix.net/rotisserie/rotisserie-ocr:$$(cat $(REV_FILE))"
+	docker push "registry.ng.bluemix.net/rotisserie/rotisserie-static:$$(cat $(REV_FILE))"
 
 # Runs all image related tasks.
 all-images: set-rev images tag-images upload-images

--- a/deploy/rotisserie.yaml
+++ b/deploy/rotisserie.yaml
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
       - name: rotisserie-static
-        image: $docker_username/rotisserie-static:$IMAGE_TAG
+        image: registry.ng.bluemix.net/rotisserie/rotisserie-static:$IMAGE_TAG
         imagePullPolicy: Always
         env:
         - name: NGINX_LISTEN
@@ -67,7 +67,7 @@ spec:
     spec:
       containers:
         - name: rotisserie-app
-          image: $docker_username/rotisserie-app:$IMAGE_TAG
+          image: registry.ng.bluemix.net/rotisserie/rotisserie-app:$IMAGE_TAG
           env:
           - name: token
             valueFrom:
@@ -94,7 +94,7 @@ spec:
     spec:
       containers:
         - name: rotisserie-ocr
-          image: $docker_username/rotisserie-ocr:$IMAGE_TAG
+          image: registry.ng.bluemix.net/rotisserie/rotisserie-ocr:$IMAGE_TAG
           ports:
             - containerPort: 3001
 ---


### PR DESCRIPTION
Since we have multiple people deploying the application it looks sloppy using docker repositories. Switched back to using the container registry. Tested with a deployment on my test domain and didn't run into any issues. 