### PR TITLE
Updated configmaps in templates to match naming

### DIFF
--- a/helm/rotisserie/Chart.yaml
+++ b/helm/rotisserie/Chart.yaml
@@ -1,5 +1,7 @@
 apiVersion: v1
 appVersion: "1.0"
-description: A Helm chart for Kubernetes
+description: A Helm chart for Rotisserie.tv
 name: rotisserie
-version: 0.1.0
+version: 0.1.1
+sources:
+  - https://github.com/IBM/rotisserie

--- a/helm/rotisserie/templates/kube-lego.yaml
+++ b/helm/rotisserie/templates/kube-lego.yaml
@@ -19,12 +19,12 @@ spec:
         - name: LEGO_EMAIL
           valueFrom:
             configMapKeyRef:
-              name: kube-lego
+              name: {{ template "rotisserie.fullname" . }}-kube-lego
               key: lego.email
         - name: LEGO_URL
           valueFrom:
             configMapKeyRef:
-              name: kube-lego
+              name: {{ template "rotisserie.fullname" . }}-kube-lego
               key: lego.url
         - name: LEGO_POD_IP
           valueFrom:
@@ -62,7 +62,7 @@ spec:
         args:
         - /nginx-ingress-controller
         - --default-backend-service=default/{{ template "rotisserie.fullname" . }}-static
-        - --nginx-configmap=default/nginx
+        - --nginx-configmap=default/{{ template "rotisserie.fullname" . }}-nginx
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
The old configmap names were still setup in the templates. This worked on test clusters since they were never removed. After removing them in prod I ran into issues finding the configmap resources using the old naming style, but was able to resolve it by using the new name. Also moved the release to 0.1.1 and added sources in the Chart file. 