### PR TITLE
Add ibm metrics collector client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # rotisserie
 
+![IBM Cloud Deployments](https://metrics-tracker.mybluemix.net/stats/b7e0679c800a31bc460ba070d7a47776/badge.svg)
 [![Build Status](https://api.travis-ci.org/IBM/rotisserie.svg?branch=master)](https://travis-ci.org/IBM/rotisserie)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/deploy/rotisserie.yaml
+++ b/deploy/rotisserie.yaml
@@ -127,3 +127,24 @@ spec:
         backend:
           serviceName: rotisserie-app
           servicePort: 3000
+---
+apiVersion: batch/v1
+kind: Job
+metadata: {name: 'rotisseriemetrics'}
+spec:
+  template:
+    metadata: {name: 'rotisseriemetrics'}
+    spec:
+      containers:
+        - env:
+            - {name: config, value: '{"event_id": "web",
+                "repository_id": "https://github.com/IBM/rotisserie",
+                "target_services": [null], "target_runtimes":
+                ["Kubernetes Cluster"], "event_organizer":
+                "dev-journeys"}'}
+            - {name: language, value: node.js}
+          image: journeycode/kubernetes:latest
+          name: 'rotisseriemetrics'
+          resources:
+            limits: {cpu: 100m}
+      restartPolicy: Never

--- a/helm/rotisserie/templates/rotisserie.yaml
+++ b/helm/rotisserie/templates/rotisserie.yaml
@@ -156,3 +156,24 @@ spec:
           serviceName: {{ template "rotisserie.fullname" $ }}-app
           servicePort: 3000
   {{- end }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata: {name: '{{ template "rotisserie.fullname" . }}-metrics'}
+spec:
+  template:
+    metadata: {name: '{{ template "rotisserie.fullname" . }}-metrics'}
+    spec:
+      containers:
+        - env:
+            - {name: config, value: '{"event_id": "web",
+                "repository_id": "https://github.com/IBM/rotisserie",
+                "target_services": [null], "target_runtimes":
+                ["Kubernetes Cluster"], "event_organizer":
+                "dev-journeys"}'}
+            - {name: language, value: node.js}
+          image: journeycode/kubernetes:latest
+          name: '{{ template "rotisserie.fullname" . }}-metrics'
+          resources:
+            limits: {cpu: 100m}
+      restartPolicy: Never


### PR DESCRIPTION
This will make use of the IBM Metrics Collector Client, which seems
to be a desired thing for all of IBM's code patterns to track our
kubernetes deployments. I will presumably need to shutdown/migrate
our google analytics stuff anyway.

The information on this should stay static, so it shouldn't need to
be templated any further.

Reference:
https://github.com/IBM/metrics-collector-client-kubernetes

Signed-off-by: Cullen Taylor <mctaylor@us.ibm.com>