### PR TITLE
Add timestamps and log levels to log messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "rotisserie",
+  "name": "rotisserietv",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
@@ -801,18 +801,6 @@
         "assert-plus": "1.0.0"
       }
     },
-    "glob": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-      "requires": {
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
-    },
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
@@ -1133,6 +1121,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
+    "log": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/log/-/log-1.4.0.tgz",
+      "integrity": "sha1-S6HYkP3iSbAx3KA7w36q8yVlbxw="
+    },
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
@@ -1242,13 +1235,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
-    },
-    "node-tesseract": {
-      "version": "git+https://github.com/desmondmorris/node-tesseract.git#30249786e35a2698dfae20c6534935d4f8d18420",
-      "requires": {
-        "glob": "5.0.15",
-        "uuid": "3.1.0"
-      }
     },
     "node-uuid": {
       "version": "1.4.8",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "express": "^4.15.3",
     "fluent-ffmpeg": "^2.1.2",
     "gm": "^1.23.0",
+    "log": "^1.4.0",
     "multer": "^1.3.0",
     "node-tesseract": "https://github.com/desmondmorris/node-tesseract.git",
     "node-uuid": "^1.4.8",


### PR DESCRIPTION
This will make the log messages a little more production ready. It
uses the log package from npm, and just adds a time stamp and log
level (INFO or ERROR) to each log message. It still prints to the
console so kubectl logs will work just fine.

Signed-off-by: Cullen Taylor <mctaylor@us.ibm.com>