### PR TITLE
Add support for Fortnite to OCR service

### DIFF
--- a/deploy/images/ocr.Dockerfile
+++ b/deploy/images/ocr.Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.6-slim
 
 COPY ocr/ocr.py ocr/requirements.txt /
-ADD https://s3-api.us-geo.objectstorage.softlayer.net/rotisserie-ml-models/model.pb /
+ADD https://s3-api.us-geo.objectstorage.softlayer.net/rotisserie-ml-models/pubg.pb /
+ADD https://s3-api.us-geo.objectstorage.softlayer.net/rotisserie-ml-models/fortnite.pb /
 
 RUN apt-get update && \
     apt-get -y install gcc && \

--- a/tests/test_ocr_service.sh
+++ b/tests/test_ocr_service.sh
@@ -22,7 +22,7 @@ if ! $(curl -s http://localhost:3001/info | jq '.app' | grep -q 'ocr'); then
 fi
 
 echo "Validate version"
-curl -s http://localhost:3001/info | jq '.version' | grep -q -- '0.2'
+curl -s http://localhost:3001/info | jq '.version' | grep -q -- '0.3'
 
 echo "Validate images/ocr"
 for image in tests/images/*; do


### PR DESCRIPTION
A new endpoint has been added to the OCR service which
uses a model trained for Fortnite to identify remaining
players.