### PR TITLE
Changed from clusterissuer to issuer

### DIFF
--- a/helm/rotisserie/templates/rotisserie-issuer.yaml
+++ b/helm/rotisserie/templates/rotisserie-issuer.yaml
@@ -1,7 +1,8 @@
 apiVersion: certmanager.k8s.io/v1alpha1
-kind: ClusterIssuer
+kind: Issuer
 metadata:
-  name: letsencrypt-prod
+  name: {{ template "rotisserie.fullname" . }}-letsencrypt-prod
+  namespace: {{ .Values.namespace }}
 spec:
   acme:
     # The ACME server URL

--- a/helm/rotisserie/templates/rotisserie.yaml
+++ b/helm/rotisserie/templates/rotisserie.yaml
@@ -129,8 +129,7 @@ metadata:
 spec:
   secretName: {{ template "rotisserie.fullname" . }}-tls
   issuerRef:
-    kind: ClusterIssuer
-    name: letsencrypt-prod
+    name: {{ template "rotisserie.fullname" . }}-letsencrypt-prod
   dnsNames:
   {{- range .Values.ingress.hostnames}}
   - {{ . }}

--- a/helm/rotisserie/values.yaml
+++ b/helm/rotisserie/values.yaml
@@ -2,11 +2,15 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+## Namespace
+
+# specify the namespace being used. defaults to default
+namespace: default
+
 ## Images
 
-# the repository URL for the image
+# the repository URL for the image and then the image tag
 imageRepository:
-# the tag for the image version being used
 imageTag:
 
 ## Ingress
@@ -20,12 +24,14 @@ ingress:
 
 ## Secrets
 
-# Specify secrets for the rotisserie-app.
+# Specify secrets for the rotisserie-app
 secrets:
   token:
   clientID:
 
-# Specify the email and hostname for kube-lego.
+# Cert-Manager
+
+# Specify the email and hostname for cert-manager
 certManager:
   email:
   url: https://acme-v01.api.letsencrypt.org/directory


### PR DESCRIPTION
Switched from a clusterissuer to an issuer. This will create a per install issuer which will be named and controlled by the helm release name. Also added the option for setting the namespace for Cert-Manager in the values file. 